### PR TITLE
Remove pymc3

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -16,7 +16,6 @@ dependencies:
   - palettable
   - pandas
   - pillow
-  - pymc3
   - scikit-learn
   - seaborn
   - statsmodels


### PR DESCRIPTION
This will make the environment work on OS X and we don't really need it.